### PR TITLE
Added support for 'ü' tones

### DIFF
--- a/lib/phoneticize.js
+++ b/lib/phoneticize.js
@@ -1,9 +1,9 @@
 var notation = {
-    1: "āēīōū"
-  , 2: "áéíóú"
-  , 3: "ǎěǐǒǔ"
-  , 4: "àèìòù"
-  , 5: "aeiou"
+    1: "āēīōūǖ"
+  , 2: "áéíóúǘ"
+  , 3: "ǎěǐǒǔǚ"
+  , 4: "àèìòùǜ"
+  , 5: "aeiouü"
 }
 
 // phoneticizing yay,yay,yay!
@@ -19,7 +19,7 @@ module.exports = exports = function(words) {
 
     if(note === 5) return tmp.push(char.toLowerCase());
 
-    result = char.toLowerCase().replace(/([aeiou])/, function(i, match){
+    result = char.toLowerCase().replace('v','ü').replace(/([aeiouü])/, function(i, match){
       var at = notation[5].indexOf(match)
       return notation[note].charAt(at);
     })


### PR DESCRIPTION
'ü' was shown as 'v' with no tone information when calling the `pinyin` method:

```
> require('./han.js').pinyin('女')
[ [ 'nv', 'rǔ' ] ]
```

I've modified the file `lib/phoneticize.js` to correct that:

```
> require('./han.js').pinyin('女')
[ [ 'nǚ', 'rǔ' ] ]
```
